### PR TITLE
Overwrite old results opposed to appending.

### DIFF
--- a/githump.sh
+++ b/githump.sh
@@ -158,7 +158,7 @@ for target in ${BASH_ARGV[*]}; do
   # accumulate all the unique emails
   # -----------------------------------------------------------
   address_count=$(find "${temp_dir}/${target}" -name "*.results" -type f -exec cat "{}" + | sort | uniq | wc -l)
-  find "${temp_dir}/${target}" -name "*.results" -type f -exec cat "{}" + | sort | uniq >> "./results/${target}.txt"
+  find "${temp_dir}/${target}" -name "*.results" -type f -exec cat "{}" + | sort | uniq > "./results/${target}.txt"
   rm -rf "${temp_dir}/${target}"
   log_success "Collected ${address_count} emails for $target, stored in ./results/${target}.txt"
 


### PR DESCRIPTION
This change prevents the results file from growing with repeated data if githump is run more than once on a single repository.